### PR TITLE
prevent double slash in shinage-client.js

### DIFF
--- a/src/AppBundle/Resources/public/js/shinage-client.js
+++ b/src/AppBundle/Resources/public/js/shinage-client.js
@@ -21,6 +21,9 @@ $(document).ready(function() {
         //alert(s.file);
         console.log(s);
 
+        //make sure there is no trailing slash
+        img_base = img_base.replace(/\/+$/, '');
+
         var n = document.createElement("div");
         $(n).addClass('slide-img');
         $(n).addClass('slide-'+id);


### PR DESCRIPTION
This is maybe not the perfect space to fix this (maybe better would be generating a string without trailing slash in the first place), but now the presentation should create image addresses in the style of `.../user/image.jpg`